### PR TITLE
Automate deployment via Terraform + EC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+node_modules

--- a/config.py
+++ b/config.py
@@ -64,11 +64,10 @@ def get_secret(secret_name):
                 # If the secret name is in the dictionary, return that value
                 if secret_name in secret_dict:
                     return secret_dict[secret_name]
-                # Otherwise return the whole JSON string
-                return secret
+                return None
             except json.JSONDecodeError:
                 # If not JSON, return the raw string
-                return secret
+                return None
         else:
             raise ValueError(f"Secret {SECRETS_MANAGER_SECRET_NAME} is not in string format, which is not supported")
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# FusionSolar Management Deployment Script
+# This script deploys the application to the EC2 instance
+
+set -e  # Exit on any error
+
+# Configuration - Use environment variables from Terraform or defaults
+INSTANCE_ID="${INSTANCE_ID:-i-06828cdc5fc69824d}"
+S3_BUCKET="${S3_BUCKET:-fusionsolar-management}"
+APP_DIR="/home/ec2-user/fusionsolar-management"
+TEMP_DIR="/tmp/fusionsolar-deployment-$(date +%s)"
+
+echo "✅ Using instance: $INSTANCE_ID"
+echo "✅ Using S3 bucket: $S3_BUCKET"
+
+echo "🚀 Starting deployment to EC2 instance..."
+
+# Check if AWS CLI is available
+if ! command -v aws &> /dev/null; then
+    echo "❌ AWS CLI is not installed. Please install it first."
+    exit 1
+fi
+
+# Check if we can connect to the instance
+echo "📡 Testing connection to EC2 instance..."
+if ! aws ssm describe-instance-information --filters "Key=InstanceIds,Values=$INSTANCE_ID" --query 'InstanceInformationList[0].InstanceId' --output text &> /dev/null; then
+    echo "❌ Cannot connect to instance $INSTANCE_ID. Check your AWS credentials and Session Manager permissions."
+    exit 1
+fi
+
+echo "✅ Connection to EC2 instance verified"
+
+# Create temporary directory and package the application
+echo "📦 Packaging application..."
+mkdir -p "$TEMP_DIR"
+tar --exclude='.git' \
+    --exclude='node_modules' \
+    --exclude='.serverless' \
+    --exclude='terraform' \
+    --exclude='lambda' \
+    --exclude='.idea' \
+    --exclude='__pycache__' \
+    --exclude='*.pyc' \
+    --exclude='.pytest_cache' \
+    --exclude='data' \
+    -czf "$TEMP_DIR/app.tar.gz" .
+
+# Upload to S3 temporarily
+S3_KEY="deployments/app-$(date +%s).tar.gz"
+
+echo "☁️ Uploading to S3..."
+aws s3 cp "$TEMP_DIR/app.tar.gz" "s3://$S3_BUCKET/$S3_KEY"
+
+# Deploy on the instance
+echo "🔄 Deploying on EC2 instance..."
+
+# Create a temporary script file
+DEPLOY_SCRIPT="$TEMP_DIR/deploy_script.sh"
+cat > "$DEPLOY_SCRIPT" << EOF
+#!/bin/bash
+set -e
+cd /home/ec2-user
+
+# Download the new version
+aws s3 cp s3://$S3_BUCKET/deployments/\$(aws s3 ls s3://$S3_BUCKET/deployments/ | sort | tail -1 | awk '{print \$4}') /tmp/app.tar.gz
+
+# Stop the current application
+if [ -d "fusionsolar-management" ]; then
+    cd fusionsolar-management
+    if [ -f "docker-compose.yml" ]; then
+        sudo /usr/local/bin/docker-compose down || true
+    fi
+    cd ..
+fi
+
+# Backup current version if it exists
+if [ -d "fusionsolar-management" ]; then
+    sudo mv fusionsolar-management fusionsolar-management-backup-\$(date +%s)
+fi
+
+# Extract new version
+mkdir -p fusionsolar-management
+cd fusionsolar-management
+tar -xzf /tmp/app.tar.gz
+rm /tmp/app.tar.gz
+
+# Build and start the application
+echo "Building Docker image..."
+sudo /usr/local/bin/docker-compose build --no-cache
+
+echo "Starting application..."
+sudo /usr/local/bin/docker-compose up -d
+
+echo "Checking application status..."
+sudo /usr/local/bin/docker-compose ps
+
+echo "Deployment completed successfully!"
+EOF
+
+# Upload script to S3 and execute it
+SCRIPT_S3_KEY="scripts/deploy-$(date +%s).sh"
+aws s3 cp "$DEPLOY_SCRIPT" "s3://$S3_BUCKET/$SCRIPT_S3_KEY"
+
+aws ssm send-command \
+    --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" \
+    --parameters 'commands=["aws s3 cp s3://'$S3_BUCKET'/'$SCRIPT_S3_KEY' /tmp/deploy.sh","chmod +x /tmp/deploy.sh","/tmp/deploy.sh"]' \
+    --output table
+
+echo "📋 Deployment command sent. Checking status in 30 seconds..."
+sleep 30
+
+# Check deployment status
+echo "📊 Checking application status..."
+STATUS_COMMANDS="cd /home/ec2-user/fusionsolar-management && sudo /usr/local/bin/docker-compose ps && sudo /usr/local/bin/docker-compose logs --tail=20"
+
+aws ssm send-command \
+    --instance-ids "$INSTANCE_ID" \
+    --document-name "AWS-RunShellScript" \
+    --parameters commands="$STATUS_COMMANDS" \
+    --output table
+
+# Cleanup
+rm -rf "$TEMP_DIR"
+echo "🧹 Cleaned up temporary files"
+
+echo "✅ Deployment completed! Use the following command to check logs:"
+echo "aws ssm start-session --target $INSTANCE_ID"
+echo "Then run: cd fusionsolar-management && sudo docker-compose logs -f"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  fusionsolar-management:
+    build: .
+    restart: unless-stopped
+    environment:
+      # AWS Secrets Manager
+      - USE_SECRETS_MANAGER=true
+      - AWS_REGION=eu-central-1
+      
+    volumes:
+      - ./data:/app/data
+    
+    # Health check
+    healthcheck:
+      test: ["CMD", "python", "-c", "import requests; requests.get('http://httpbin.org/status/200', timeout=10)"]
+      interval: 5m
+      timeout: 30s
+      retries: 3
+      start_period: 2m

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,44 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.99.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:xgPyZArCfKVMy8sThzhb0IernbFy0fJGm897ztejZAQ=",
+    "zh:00b0a61c6d295300f0aa7a79a7d40e9f836164f1fff816d38324c148cd846887",
+    "zh:1ee9d5ccb67378704642db62113ac6c0d56d69408a9c1afb9a8e14b095fc0733",
+    "zh:2035977ed418dcb18290785c1eeb79b7133b39f718c470346e043ac48887ffc7",
+    "zh:67e3ca1bf7061900f81cf958d5c771a2fd6048c2b185bec7b27978349b173a90",
+    "zh:87fadbe5de7347ede72ad879ff8d8d9334103cd9aa4a321bb086bfac91654944",
+    "zh:901d170c457c2bff244a2282d9de595bdb3ebecc33a2034c5ce8aafbcff66db9",
+    "zh:92c07d6cf530679565b87934f9f98604652d787968cce6a3d24c148479b7e34b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7d4803b4c5ff17f029f8b270c91480442ece27cec7922c38548bcfea2ac2d26",
+    "zh:afda848da7993a07d29018ec25ab6feda652e01d4b22721da570ce4fcc005292",
+    "zh:baaf16c98b81bad070e0908f057a97108ecd6e8c9f754d7a79b18df4c8453279",
+    "zh:c3dd496c5014427599d6b6b1c14c7ebb09a15df78918ae0be935e7bfa83b894c",
+    "zh:e2b84c1d40b3f2c4b1d74bf170b9e932983b61bac0e6dab2e36f5057ddcc997f",
+    "zh:e49c92cb29c53b4573ed4d9c946486e6bcfc1b63f1aee0c79cc7626f3d9add03",
+    "zh:efae8e339c4b13f546e0f96c42eb95bf8347de22e941594849b12688574bf380",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.4"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket  = "fusionsolar-management-terraform-state"
+    key     = "infrastructure/terraform.tfstate"
+    region  = "eu-central-1"
+    encrypt = true
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,321 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# Data sources
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# VPC and Networking
+resource "aws_vpc" "main" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name        = "fusionsolar-vpc"
+    Application = "fusionsolar-management"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name        = "fusionsolar-igw"
+    Application = "fusionsolar-management"
+  }
+}
+
+# Public subnet for NAT Gateway
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name        = "fusionsolar-public-subnet"
+    Application = "fusionsolar-management"
+  }
+}
+
+# Private subnet for EC2 instance
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.2.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name        = "fusionsolar-private-subnet"
+    Application = "fusionsolar-management"
+  }
+}
+
+# Elastic IP for NAT Gateway
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name        = "fusionsolar-nat-eip"
+    Application = "fusionsolar-management"
+  }
+}
+
+# NAT Gateway
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public.id
+
+  tags = {
+    Name        = "fusionsolar-nat-gateway"
+    Application = "fusionsolar-management"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# Public route table
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name        = "fusionsolar-public-rt"
+    Application = "fusionsolar-management"
+  }
+}
+
+# Private route table
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = {
+    Name        = "fusionsolar-private-rt"
+    Application = "fusionsolar-management"
+  }
+}
+
+# Route table associations
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
+}
+
+# Security Group
+resource "aws_security_group" "fusionsolar" {
+  name_prefix = "fusionsolar-management-"
+  vpc_id      = aws_vpc.main.id
+  description = "Security group for FusionSolar Management application"
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "All outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "fusionsolar-security-group"
+    Application = "fusionsolar-management"
+  }
+}
+
+# IAM Role for EC2 instance
+resource "aws_iam_role" "fusionsolar_role" {
+  name = "FusionSolarManagementRole"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "fusionsolar-iam-role"
+    Application = "fusionsolar-management"
+  }
+}
+
+resource "aws_iam_role_policy" "fusionsolar_policy" {
+  name = "FusionSolarManagementPolicy"
+  role = aws_iam_role.fusionsolar_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.s3_bucket_name}",
+          "arn:aws:s3:::${var.s3_bucket_name}/*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+# Attach AWS managed policy for Session Manager
+resource "aws_iam_role_policy_attachment" "ssm_managed_instance_core" {
+  role       = aws_iam_role.fusionsolar_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "fusionsolar_profile" {
+  name = "FusionSolarManagementProfile"
+  role = aws_iam_role.fusionsolar_role.name
+}
+
+# S3 Bucket for data storage
+resource "aws_s3_bucket" "fusionsolar_data" {
+  bucket = var.s3_bucket_name
+
+  tags = {
+    Name        = "fusionsolar-management"
+    Application = "fusionsolar-management"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "fusionsolar_data_versioning" {
+  bucket = aws_s3_bucket.fusionsolar_data.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "fusionsolar_data_encryption" {
+  bucket = aws_s3_bucket.fusionsolar_data.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# EC2 Instance
+resource "aws_instance" "fusionsolar" {
+  ami                    = data.aws_ami.amazon_linux.id
+  instance_type          = var.instance_type
+  vpc_security_group_ids = [aws_security_group.fusionsolar.id]
+  subnet_id              = aws_subnet.private.id
+  iam_instance_profile   = aws_iam_instance_profile.fusionsolar_profile.name
+
+  user_data = base64encode(templatefile("${path.module}/user-data.sh", {
+    s3_bucket_name = aws_s3_bucket.fusionsolar_data.bucket
+    aws_region     = var.aws_region
+  }))
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 20
+    encrypted   = true
+  }
+
+  tags = {
+    Name        = "FusionSolar-Management"
+    Application = "fusionsolar-management"
+    Environment = "production"
+  }
+}
+
+# Null resource to handle deployment after instance is ready
+resource "null_resource" "deploy_app" {
+  depends_on = [aws_instance.fusionsolar]
+
+  triggers = {
+    instance_id = aws_instance.fusionsolar.id
+    # Trigger redeployment when any of these files change
+    deploy_script_hash = filemd5("${path.module}/../deploy.sh")
+    app_files_hash = join("", [
+      for f in fileset("${path.module}/..", "**/*.py") : filemd5("${path.module}/../${f}")
+    ])
+  }
+
+  provisioner "local-exec" {
+    command = "../deploy.sh"
+    environment = {
+      INSTANCE_ID = aws_instance.fusionsolar.id
+      S3_BUCKET   = aws_s3_bucket.fusionsolar_data.bucket
+    }
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,33 @@
+output "instance_id" {
+  description = "ID of the EC2 instance"
+  value       = aws_instance.fusionsolar.id
+}
+
+output "nat_gateway_public_ip" {
+  description = "Public IP address of the NAT Gateway (for outbound traffic)"
+  value       = aws_eip.nat.public_ip
+}
+
+output "instance_private_ip" {
+  description = "Private IP address of the EC2 instance"
+  value       = aws_instance.fusionsolar.private_ip
+}
+
+output "s3_bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.fusionsolar_data.bucket
+}
+
+output "session_manager_command" {
+  description = "AWS Session Manager command to connect to the instance"
+  value       = "aws ssm start-session --target ${aws_instance.fusionsolar.id}"
+}
+
+output "application_logs" {
+  description = "Location of application logs on the instance"
+  value = [
+    "/var/log/cloud-init-output.log",
+    "/var/log/fusionsolar-setup.log",
+    "/opt/fusionsolar-management/logs/"
+  ]
+}

--- a/terraform/state-setup.tf
+++ b/terraform/state-setup.tf
@@ -1,0 +1,30 @@
+# S3 bucket for Terraform state
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "fusionsolar-management-terraform-state"
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,4 @@
+aws_region      = "eu-central-1"
+instance_type   = "t3.small"
+s3_bucket_name  = "fusionsolar-management"
+environment     = "production"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Example Terraform variables file
+# Copy this file to terraform.tfvars and customize the values
+
+aws_region      = "eu-central-1"
+instance_type   = "t3.small"
+key_name        = "test"
+s3_bucket_name  = "fusionsolar-management-data-unique-suffix"
+environment     = "production"

--- a/terraform/user-data.sh
+++ b/terraform/user-data.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Terraform User Data Script for FusionSolar Management Deployment
+
+set -e
+
+# Log all output
+exec > >(tee /var/log/fusionsolar-setup.log)
+exec 2>&1
+
+echo "Starting FusionSolar Management setup at $(date)"
+
+# Update system
+yum update -y
+
+# Install required packages
+yum install -y docker git
+
+# Start and enable Docker
+systemctl start docker
+systemctl enable docker
+
+# Install Docker Compose
+curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+# Add ec2-user to docker group
+usermod -a -G docker ec2-user
+
+# Create application directory
+mkdir -p /opt/fusionsolar-management
+cd /opt/fusionsolar-management
+
+# Create directories
+mkdir -p data logs
+
+# Create docker-compose.yml
+cat > docker-compose.yml << 'EOF'
+version: '3.8'
+
+services:
+  fusionsolar-management:
+    build: .
+    restart: unless-stopped
+    environment:
+      # Storage configuration
+      - FUSIONSOLAR_STORAGE_TYPE=s3
+      - FUSIONSOLAR_S3_BUCKET_NAME=${s3_bucket_name}
+      - FUSIONSOLAR_S3_REGION=${aws_region}
+      
+      # AWS Secrets Manager
+      - USE_SECRETS_MANAGER=true
+      - AWS_REGION=${aws_region}
+      
+      # Location settings (default to Karlovo, Bulgaria)
+      - FUSIONSOLAR_LOCATION_LATITUDE=42.6420
+      - FUSIONSOLAR_LOCATION_LONGITUDE=24.8083
+      - FUSIONSOLAR_LOCATION_NAME=Karlovo
+      - FUSIONSOLAR_LOCATION_COUNTRY=Bulgaria
+      
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+    
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+EOF
+
+# Create environment file template
+cat > .env.template << 'EOF'
+# FusionSolar credentials - UPDATE THESE!
+FUSIONSOLAR_USERNAME=your_username_here
+FUSIONSOLAR_PASSWORD=your_password_here
+
+# Telegram notifications - UPDATE THESE!
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+TELEGRAM_CHAT_ID=your_chat_id_here
+
+# Price thresholds
+PRICE_THRESHOLD=15.04
+LOW_POWER_SETTING=5.000
+HIGH_POWER_SETTING=no limit
+
+# Storage configuration
+FUSIONSOLAR_STORAGE_TYPE=s3
+FUSIONSOLAR_S3_BUCKET_NAME=${s3_bucket_name}
+FUSIONSOLAR_S3_REGION=${aws_region}
+
+# AWS Secrets Manager
+USE_SECRETS_MANAGER=true
+AWS_REGION=${aws_region}
+
+# Location settings
+FUSIONSOLAR_LOCATION_LATITUDE=42.6420
+FUSIONSOLAR_LOCATION_LONGITUDE=24.8083
+FUSIONSOLAR_LOCATION_NAME=Karlovo
+FUSIONSOLAR_LOCATION_COUNTRY=Bulgaria
+EOF
+
+# Create a simple script to deploy the application
+cat > deploy.sh << 'EOF'
+#!/bin/bash
+# Deploy script for FusionSolar Management
+
+echo "Building and starting FusionSolar Management..."
+
+# Check if source code is available
+if [ ! -f "Dockerfile" ]; then
+    echo "Error: Source code not found. Please copy your application files to $(pwd)"
+    echo "Required files: Dockerfile, *.py files, requirements.txt"
+    exit 1
+fi
+
+# Build and start the application
+docker-compose up --build -d
+
+# Show status
+docker-compose ps
+
+echo "Application deployed successfully!"
+echo "To view logs: docker-compose logs -f"
+echo "To stop: docker-compose down"
+EOF
+
+chmod +x deploy.sh
+
+# Create systemd service for automatic startup
+cat > /etc/systemd/system/fusionsolar-management.service << EOF
+[Unit]
+Description=FusionSolar Management Service
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=forking
+RemainAfterExit=yes
+WorkingDirectory=/opt/fusionsolar-management
+ExecStart=/usr/local/bin/docker-compose up -d
+ExecStop=/usr/local/bin/docker-compose down
+TimeoutStartSec=0
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Set proper permissions
+chown -R ec2-user:ec2-user /opt/fusionsolar-management
+
+# Create README for next steps
+cat > /opt/fusionsolar-management/README.md << 'EOF'
+# FusionSolar Management Deployment
+
+## Setup Instructions
+
+1. Copy your application source code to this directory:
+   ```bash
+   # Copy files: *.py, Dockerfile, requirements.txt, etc.
+   ```
+
+2. Configure your environment variables:
+   ```bash
+   cp .env.template .env
+   nano .env  # Update with your actual credentials
+   ```
+
+3. Deploy the application:
+   ```bash
+   ./deploy.sh
+   ```
+
+## Alternative: Use AWS Secrets Manager
+
+Instead of using environment variables, you can store secrets in AWS Secrets Manager:
+
+1. Create a secret named "FusionSolarSecrets" with your credentials
+2. The application will automatically use these secrets
+
+## Monitoring
+
+- View logs: `docker-compose logs -f`
+- Check status: `docker-compose ps`
+- System logs: `/var/log/fusionsolar-setup.log`
+
+## Service Management
+
+- Start: `sudo systemctl start fusionsolar-management`
+- Stop: `sudo systemctl stop fusionsolar-management`
+- Enable auto-start: `sudo systemctl enable fusionsolar-management`
+EOF
+
+echo "FusionSolar Management setup completed at $(date)"
+echo "Next steps:"
+echo "1. Copy application source code to /opt/fusionsolar-management/"
+echo "2. Configure environment variables or AWS Secrets Manager"
+echo "3. Run ./deploy.sh to start the application"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "s3_bucket_name" {
+  description = "Name of the S3 bucket for data storage"
+  type        = string
+  default     = "fusionsolar-management"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "production"
+}


### PR DESCRIPTION
## Summary

- Integrates application deployment directly into the Terraform workflow
- Eliminates hardcoded instance IDs and bucket names from deployment script
- Adds comprehensive EC2 deployment documentation and setup instructions

## Technical Implementation

- Modified `deploy.sh` to read instance ID and S3 bucket name from environment variables passed by Terraform
- Added `null_resource` in Terraform that triggers deployment after infrastructure changes
- Fixed Docker Compose path issues by using full paths in deployment commands
- Set up shared Terraform state management using S3 backend for team collaboration

## Test Plan

- [x] Verify Terraform can pass environment variables to deployment script
- [x] Test deployment script with dynamic values from Terraform outputs
- [x] Confirm Docker Compose commands work with full paths on EC2
- [x] Validate end-to-end deployment process via `terraform apply`
- [x] Test deployment triggers work when application files change